### PR TITLE
Check if CVE data not found on NIST NVD

### DIFF
--- a/playbooks/02 - Use Case - ICS Advisory and CVEs/Get And Update CVE.json
+++ b/playbooks/02 - Use Case - ICS Advisory and CVEs/Get And Update CVE.json
@@ -39,7 +39,7 @@
             },
             "status": null,
             "top": "300",
-            "left": "125",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "35ecf89d-278b-4d1b-9dbe-a2e984fa2ab0"
@@ -54,7 +54,7 @@
             },
             "status": null,
             "top": "165",
-            "left": "125",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "4126b601-fd04-4d00-81bc-1c60a6c332b3"
@@ -67,8 +67,8 @@
                 "results": "{% set output = ({\"uuid\":vars.record['uuid'], \"cVEId\":vars.record['cVEID']}) %}{% if vars.CVEData | length > 0 %}{% set _ = output.update({\"status\": \"Found\"}) %}{% else %}{% set _ = output.update({\"status\": \"Not Found\"}) %}{% endif %}{{output}}"
             },
             "status": null,
-            "top": "705",
-            "left": "125",
+            "top": "840",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "4dc7573d-0861-44f4-b254-f5f040f89a24"
@@ -78,7 +78,6 @@
             "name": "Update CVE",
             "description": null,
             "arguments": {
-                "when": "{{vars.CVEData | length > 0}}",
                 "resource": {
                     "cWEID": "{% if vars.CVEData[0].cve.get(\"weaknesses\", \"\") != \"\" %}{% set cwe = vars.CVEData[0].cve['weaknesses'] | json_query(\"[*][description][][][value][]\") | unique %}{{cwe | join(', ')}}{% endif %}",
                     "__link": {
@@ -116,8 +115,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
-            "left": "125",
+            "top": "700",
+            "left": "520",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "7cdae58e-6005-453b-8fb2-569de37f0b57"
@@ -135,7 +134,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "125",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "c4ec48ec-7113-4fb7-9608-bd503b4c2bf9"
@@ -148,23 +147,51 @@
                 "severityValue": "{% if  (vars.CVEData[0].cve.metrics.keys() | string | regex_findall('cvssMetricV3[0-9]'))[0] %}{% set version = vars.CVEData[0].cve.metrics.keys() | max %}{% set _value = vars.CVEData[0].cve.metrics.get(version)[0].cvssData.baseSeverity %}{% elif  (vars.CVEData[0].cve.metrics.keys() | string | regex_findall('cvssMetricV2'))[0] %}{% set _value = vars.CVEData[0].cve['metrics']['cvssMetricV2'][0]['baseSeverity'] %}{% endif %}{{_value | resolveRange(vars.severityMap)}}"
             },
             "status": null,
-            "top": "435",
-            "left": "125",
+            "top": "560",
+            "left": "520",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "d9170e58-34dc-4743-b048-ad63d87cea4c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "CVE Data Found",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/d9170e58-34dc-4743-b048-ad63d87cea4c",
+                        "condition": "{{ vars.CVEData | length > 0 }}",
+                        "step_name": "Set Severity Value"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/4dc7573d-0861-44f4-b254-f5f040f89a24",
+                        "step_name": "Output"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "218",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "64a7788a-14b0-4287-8e83-ec8acbedcaeb"
         }
     ],
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Get CVE Details by ID -> Set Severity Value",
-            "targetStep": "\/api\/3\/workflow_steps\/d9170e58-34dc-4743-b048-ad63d87cea4c",
+            "name": "Get CVE Details by ID -> CVE Data Found",
+            "targetStep": "\/api\/3\/workflow_steps\/64a7788a-14b0-4287-8e83-ec8acbedcaeb",
             "sourceStep": "\/api\/3\/workflow_steps\/35ecf89d-278b-4d1b-9dbe-a2e984fa2ab0",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "984007a5-d2ed-4bfd-bc04-6f06a6074f28"
+            "uuid": "2e77d635-aa58-4dab-bfc1-8e7e81e0df94"
         },
         {
             "@type": "WorkflowRoute",
@@ -175,6 +202,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "6f5e5de7-0385-4d63-ad1b-d633c26cdb31"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "CVE Data Found -> Output",
+            "targetStep": "\/api\/3\/workflow_steps\/4dc7573d-0861-44f4-b254-f5f040f89a24",
+            "sourceStep": "\/api\/3\/workflow_steps\/64a7788a-14b0-4287-8e83-ec8acbedcaeb",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ccf5a308-3549-40b6-a8d4-99eaf57b49a7"
         },
         {
             "@type": "WorkflowRoute",
@@ -195,6 +232,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "f07f7e27-67c2-48f3-9db1-8b3a2702badd"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "CVE Data Found -> Set Severity Value",
+            "targetStep": "\/api\/3\/workflow_steps\/d9170e58-34dc-4743-b048-ad63d87cea4c",
+            "sourceStep": "\/api\/3\/workflow_steps\/64a7788a-14b0-4287-8e83-ec8acbedcaeb",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b0a276bf-9cbf-4e4e-8898-04b5fe49a004"
         },
         {
             "@type": "WorkflowRoute",


### PR DESCRIPTION
Description:
1. Updated playbook "Get and Update CVE" for not found CVE data in NIST NVD Connector.

Fix:
1. Added decision step to check for not found CVE data.

UTC:
1. Verified that playbook "Get Latest Report of CVE" execute successfully for not CVE on ICS Advisory and KEV Alert module.
 