### PR TITLE
Bug Fix: 0936018

### DIFF
--- a/connectors/data.json
+++ b/connectors/data.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "csv-data-management",
+        "label": "CSV Data Management",
+        "category": null,
+        "description": "CSV Data management can perform different operations on CSV files like read file, perform deduplication, merge two CSV files, join two CSV files, concat two CSV files and return well formatted dataset",
+        "publisher": null,
+        "operation_roles": [],
+        "configurations": [],
+        "dataImports": [],
+        "install_mode": "rpm"
+    },
+    {
         "name": "cisa-advisory",
         "label": "CISA Advisory",
         "category": "Utilities",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,14 +15,16 @@ The simulation mode has some sample data that helps you get a better understandi
 
 ### Before Running the Simulation:
 
-1. Run the Simulation **OT - Add Sample Assets** from **OT - Asset Management** solution pack to get sample Assets.
-2. To get real data of listed CVEs configure **NIST National Vulnerability Database (NVD)**
+1. To get real data of listed CVEs configure **NIST National Vulnerability Database (NVD)**
 
 **OT - Known Exploited Vulnerability (KEV) Alert Raised For Asset At Risk**
 
 - Set global variable **Demo_mode** as **true**.
 - Browse to **Simulations** > **OT - Known Exploited Vulnerability (KEV) Alert Raised For Asset At Risk** scenario and click Simulate Scenario.
 - List of Records gets created.
+    - Assets:
+        - Stratix Services Router - 6241
+        - Stratix Services Router - RA41RT
     - CVEs:
         - CVE-2018-0158, CVE-2018-0151, CVE-2018-0175
     - ICS Advisory:

--- a/info.json
+++ b/info.json
@@ -139,6 +139,10 @@
         ],
         "connectors": [
             {
+                "name": "CSV Data Management",
+                "apiName": "csv-data-management"
+            },
+            {
                 "name": "CISA Advisory",
                 "apiName": "cisa-advisory"
             },

--- a/playbooks/02 - Use Case - KEV Alert/Scenario - OT - KEV Alert On Rockwell Automation.json
+++ b/playbooks/02 - Use Case - KEV Alert/Scenario - OT - KEV Alert On Rockwell Automation.json
@@ -41,7 +41,7 @@
                 "resource": {
                     "isKEV": "\/api\/3\/picklists\/cfd49634-d25a-476f-8485-99585e589a8c",
                     "__link": {
-                        "assets": "{{vars.steps.Filter_Asset_By_Product.data | json_query('[*][\"@id\"][]')}}",
+                        "assets": "{{vars.assetList | json_query('[*][\"@id\"][]')}}",
                         "c_v_es": "{{vars.steps.Create_CVEs_Record | json_query('[*][\"@id\"][]')}}"
                     }
                 },
@@ -55,7 +55,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
+            "top": "1515",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -63,9 +63,10 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "CVEs Mock Data",
+            "name": "Mock Data",
             "description": null,
             "arguments": {
+                "assetMockIP": "[\"10.12.31.56\", \"10.120.105.12\"]",
                 "cVEMockList": "[\"CVE-2018-0158\", \"CVE-2018-0151\", \"CVE-2018-0175\"]"
             },
             "status": null,
@@ -92,7 +93,7 @@
                 "workflowReference": "\/api\/3\/workflows\/853425e6-f958-45c2-9850-f2aca7184422"
             },
             "status": null,
-            "top": "1245",
+            "top": "1785",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -233,7 +234,7 @@
                 "@id": "{{vars.recordIRI}}"
             },
             "status": null,
-            "top": "1380",
+            "top": "1920",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -304,6 +305,7 @@
             "description": null,
             "arguments": {
                 "name": "Fuzzy Search",
+                "when": "{{vars.steps.Get_Assets_By_Vendor | length > 0}}",
                 "params": {
                     "inputJSON": "{{vars.steps.Get_Assets_By_Vendor}}",
                     "fuzzyMatch": false,
@@ -315,7 +317,9 @@
                 "operation": "filter_json_by_key_value",
                 "operationTitle": "Filter JSON by Key Value",
                 "pickFromTenant": false,
-                "step_variables": []
+                "step_variables": {
+                    "assetList": "{{vars.steps.Filter_Asset_By_Product.data}}"
+                }
             },
             "status": null,
             "top": "975",
@@ -323,6 +327,134 @@
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "cfcfa9f3-45ff-4ae0-9978-107f930b6555"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Asset Found",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/234db232-8a04-47cc-acf9-a3482f94da93",
+                        "condition": "{{ vars.steps.Filter_Asset_By_Product.data | length > 0 }}",
+                        "step_name": "Update ICS Advisory"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/e81821d8-5548-4481-b455-18e3b19f1dbb",
+                        "step_name": "Get Asset Data From CSV File"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "c081cf4c-93ca-4133-bd83-31e0c3dc92b1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Asset with CVEs",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.assetList}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "__link": {
+                        "cVEs": "{{vars.steps.Create_CVEs_Record | json_query('[*][\"@id\"][]')}}"
+                    }
+                },
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/assets",
+                "fieldOperation": [],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1650",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "fd78fe0c-9b8f-4c30-b023-56a40258fd95"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create Assets Record",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.assetList}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "arguments": {
+                    "assetRecord": "{{vars.item}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "__dummy": "{{vars.recordIRI.extend(vars.steps.Create_Assets_Record| json_query('[*][\"@id\"][]'))}}",
+                    "assetList": "{{vars.steps.Create_Assets_Record}}"
+                },
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/d6017f29-92f5-464f-b41b-e55f0f4d0298"
+            },
+            "status": null,
+            "top": "1380",
+            "left": "480",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "015f69a2-e2c8-4b7d-b8ee-01c3a1ca2eef"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Asset Data From CSV File",
+            "description": null,
+            "arguments": {
+                "name": "CSV Data Management",
+                "params": {
+                    "input": "Attachment IRI",
+                    "value": "\/api\/3\/attachments\/27e7ad03-7746-46c4-9580-81b9842cbe91",
+                    "filter": "{{vars.item}}",
+                    "columnNames": "",
+                    "filterInput": "On Specified Values",
+                    "recordBatch": "",
+                    "deDupValuesOn": "",
+                    "filterColumnName": "IP Address",
+                    "saveAsAttachment": "",
+                    "numberOfRowsToSkip": ""
+                },
+                "version": "1.2.0",
+                "for_each": {
+                    "item": "{{vars.assetMockIP}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "connector": "csv-data-management",
+                "operation": "extract_data_from_csv",
+                "operationTitle": "Extract Data from Single CSV",
+                "pickFromTenant": false,
+                "step_variables": {
+                    "data": "{{vars.steps.Get_Data_From_CSV_File.data['records']| replace('N\/A', None)}}",
+                    "assetList": "{{vars.steps.Get_Asset_Data_From_CSV_File | json_query('[*][data][][records][][]') | replace('N\/A', None)}}"
+                }
+            },
+            "status": null,
+            "top": "1240",
+            "left": "480",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "e81821d8-5548-4481-b455-18e3b19f1dbb"
         }
     ],
     "routes": [
@@ -335,6 +467,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "7e12370a-ffaa-4791-aa80-098ecd607f79"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create Assets Record -> Update ICS Advisory",
+            "targetStep": "\/api\/3\/workflow_steps\/234db232-8a04-47cc-acf9-a3482f94da93",
+            "sourceStep": "\/api\/3\/workflow_steps\/015f69a2-e2c8-4b7d-b8ee-01c3a1ca2eef",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f248dad9-6ba8-4d22-b37f-b0420e84a467"
         },
         {
             "@type": "WorkflowRoute",
@@ -378,13 +520,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Filter Asset By Product -> Update ICS Advisory",
-            "targetStep": "\/api\/3\/workflow_steps\/234db232-8a04-47cc-acf9-a3482f94da93",
+            "name": "Filter Asset By Product -> Is Asset Found",
+            "targetStep": "\/api\/3\/workflow_steps\/c081cf4c-93ca-4133-bd83-31e0c3dc92b1",
             "sourceStep": "\/api\/3\/workflow_steps\/cfcfa9f3-45ff-4ae0-9978-107f930b6555",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "3ef4e21c-bdbf-459e-bb6a-119cd88118ee"
+            "uuid": "12de76f8-9ed4-4525-8adb-715807882179"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Asset Data From CSV File -> Create Assets Record",
+            "targetStep": "\/api\/3\/workflow_steps\/015f69a2-e2c8-4b7d-b8ee-01c3a1ca2eef",
+            "sourceStep": "\/api\/3\/workflow_steps\/e81821d8-5548-4481-b455-18e3b19f1dbb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2eb9ce2c-9938-4d8a-9354-55ece5f0d215"
         },
         {
             "@type": "WorkflowRoute",
@@ -408,6 +560,26 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Is Asset Found -> Get Asset Data From CSV File",
+            "targetStep": "\/api\/3\/workflow_steps\/e81821d8-5548-4481-b455-18e3b19f1dbb",
+            "sourceStep": "\/api\/3\/workflow_steps\/c081cf4c-93ca-4133-bd83-31e0c3dc92b1",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "599919e8-4f1d-41b4-b421-79e64c5f68f4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Asset Found -> Update ICS Advisory",
+            "targetStep": "\/api\/3\/workflow_steps\/234db232-8a04-47cc-acf9-a3482f94da93",
+            "sourceStep": "\/api\/3\/workflow_steps\/c081cf4c-93ca-4133-bd83-31e0c3dc92b1",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "69728d06-d852-4b81-85a1-0745d3e7862d"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Configuration",
             "targetStep": "\/api\/3\/workflow_steps\/c2559eb1-d755-44e5-9ec0-815b1d1bae30",
             "sourceStep": "\/api\/3\/workflow_steps\/12248097-3706-4c2f-be33-d227767e7f33",
@@ -418,13 +590,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update ICS Advisory -> Create KEV Record",
+            "name": "Update Asset with CVEs -> Create KEV Record",
             "targetStep": "\/api\/3\/workflow_steps\/3d389c87-5620-4330-9603-333c72502635",
+            "sourceStep": "\/api\/3\/workflow_steps\/fd78fe0c-9b8f-4c30-b023-56a40258fd95",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c0cba6e0-33e7-494b-b5c7-e611c56744b9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update ICS Advisory -> Update Asset with CVEs",
+            "targetStep": "\/api\/3\/workflow_steps\/fd78fe0c-9b8f-4c30-b023-56a40258fd95",
             "sourceStep": "\/api\/3\/workflow_steps\/234db232-8a04-47cc-acf9-a3482f94da93",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "e169c46e-dc99-4d52-89cc-16799a90a266"
+            "uuid": "1256984f-e148-40d4-a3c9-180ae56f952c"
         }
     ],
     "groups": [],


### PR DESCRIPTION
Description:
1. OT_VM_SP: Assets are not being linked with CVEs.

Fix:
1. Added the step to correlate Assets with CVEs.
2. Added the steps to check if expected assets for ICS Advisory found or not. It not then create them from OT Sample Assets CSV file. (These remove execution dependency of "OT - Add Sample Assets")
3. Doc Changes.

UTC:
1. Verified that Simulation "OT - Known Vulnerability Exploit (KVE) Alert Raised For Asset At Risk" get simulated successfully and expected record get created.
